### PR TITLE
Add Cargo package metadata for publishing to crates.io

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,14 @@
 name = "knsh"
 version = "0.0.2"
 edition = "2021"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+rust-version = "1.75.0"
+authors = ["nukopy <nukopy@gmail.com>"]
+license = "MIT"
+readme = "README.md"
+repository = "https://github.com/nukopy/knsh"
+homepage = "https://github.com/nukopy/knsh"
+description = "Toy shell written in Rust"
+categories = ["os"]
+keywords = ["shell", "sh", "cli"]
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -14,4 +14,4 @@
 [github-actions-release-badge]: https://github.com/nukopy/knsh/actions/workflows/release.yml/badge.svg?branch=main
 [github-actions-release-url]: https://github.com/nukopy/knsh/actions/workflows/release.yml?query=branch:main
 
-Shell written in Rust 
+Toy shell written in Rust 


### PR DESCRIPTION
## Why

On GitHub Actions workflow "Release", the following error occurs on publishing to crates.io:

```sh
Run cargo publish --token ***
    Updating crates.io index
warning: manifest has no description, license, license-file, documentation, homepage or repository.
See https://doc.rust-lang.org/cargo/reference/manifest.html#package-metadata for more info.
   Packaging knsh v0.0.2 (/home/runner/work/knsh/knsh)
   Verifying knsh v0.0.2 (/home/runner/work/knsh/knsh)
   Compiling knsh v0.0.2 (/home/runner/work/knsh/knsh/target/package/knsh-0.0.2)
    Finished dev [unoptimized + debuginfo] target(s) in 0.81s
    Packaged 13 files, 8.6KiB (3.8KiB compressed)
   Uploading knsh v0.0.2 (/home/runner/work/knsh/knsh)
error: failed to publish to registry at https://crates.io

Caused by:
  the remote server responded with an error: missing or empty metadata fields: description, license. Please see https://doc.rust-lang.org/cargo/reference/manifest.html for more information on configuring these fields
Error: Process completed with exit code 101.
```

The error message referred to the [Cargo documentation](https://doc.rust-lang.org/cargo/reference/publishing.html#before-publishing-a-new-crate), which indicated that the following metadata in the `Cargo.toml` file is required for publishing to crates.io:

- license or license-file
- description
- homepage
- documentation
- repository
- readme

## What

- [x] Add Cargo package metadata to `Cargo.toml`
